### PR TITLE
Add "cap" and "do be like" keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Below is a table of all of the Python keywords or operators that should be repla
 | is                      | do be like                       |
 | and                     |                                  |
 | or                      |                                  |
-| not                     |                                  |
+| not                     | cap                              |
 | with                    | pookie                           |
 | as                      | ahh                              |
 | global                  | GOAT                             |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Below is a table of all of the Python keywords or operators that should be repla
 | assert                  | sus                              |
 | raise                   | crashout                         |
 | in                      | diddy                            |
-| is                      |                                  |
+| is                      | do be like                       |
 | and                     |                                  |
 | or                      |                                  |
 | not                     |                                  |

--- a/pygyat/__init__.py
+++ b/pygyat/__init__.py
@@ -38,6 +38,7 @@ GYAT2PY_MAPPINGS = {
     "twin": "==",
     "sigma": ">",
     "beta": "<",
+    "do\s+be\s+like": "is",
     "diddy": "in",
     "pluh": "pass"
 }

--- a/pygyat/__init__.py
+++ b/pygyat/__init__.py
@@ -39,6 +39,7 @@ GYAT2PY_MAPPINGS = {
     "sigma": ">",
     "beta": "<",
     "do\s+be\s+like": "is",
+    "cap": "not",
     "diddy": "in",
     "pluh": "pass"
 }

--- a/testcases/example.gyat
+++ b/testcases/example.gyat
@@ -6,14 +6,18 @@ skibidi Rizzler:
     pluh
 
 bop kai_cenat():
-    duke_dennis = 0
+    duke_dennis = NPC
+    chat is this real duke_dennis do be like cap NPC:
+        crashout Error()
     let him cook Aura:
         chat is this real Cooked:
             duke_dennis = duke_dennis rizz 1
             crashout Error()
-        yo chat duke_dennis twin NPC:
-            duke_dennis = duke_dennis fanum tax 1
+        yo chat duke_dennis do be like NPC:
+            duke_dennis = 0
             edge
+        yo chat duke_dennis twin 0:
+            duke_dennis = duke_dennis fanum tax 1
         only in ohio:
             duke_dennis = 10
             just put the fries in the bag bro

--- a/testcases/example.py
+++ b/testcases/example.py
@@ -6,14 +6,18 @@ class Rizzler:
     pass
 
 def kai_cenat():
-    duke_dennis = 0
+    duke_dennis = None
+    if duke_dennis is not None:
+        raise Error()
     while True:
         if False:
             duke_dennis = duke_dennis + 1
             raise Error()
-        elif duke_dennis == None:
-            duke_dennis = duke_dennis - 1
+        elif duke_dennis is None:
+            duke_dennis = 0
             continue
+        elif duke_dennis == 0:
+            duke_dennis = duke_dennis - 1
         else:
             duke_dennis = 10
             break
@@ -21,7 +25,7 @@ def kai_cenat():
     try:
         print(duke_dennis)
     except:
-        [duke_dennis + 10 for duke_dennis in range(69)]
+        [baby_gronk + 10 for baby_gronk in range(69)]
 
     return True
 


### PR DESCRIPTION
`cap` -> `not` mapping is absolutely mandatory.

`do be like` -> `is` is almost as good. Another possibility is `do be`, which has more sentence-structure compatibility ("It is like that" vs "It do be like that"). However, dropping the `like` sacrifices style, which is sad fr.

Both are semantically consistent with their slang meanings and improve `pygyat`'s quality.

Also modifies `example.py` and `example.gyat` to demonstrate these features.