### PR TITLE
Add the most FIRE keywords no cap (+echo server!)

### DIFF
--- a/pygyat/__init__.py
+++ b/pygyat/__init__.py
@@ -39,5 +39,14 @@ GYAT2PY_MAPPINGS = {
     "sigma": ">",
     "beta": "<",
     "diddy": "in",
-    "pluh": "pass"
+    "pluh": "pass",
+    "outside": "async",
+    "touch\s+grass": "await",
+    "built\s+like": "=",
+    "fr": "is",
+    "cap": "not",
+    "link\s+up": "and",
+    "peep": "read",
+    "drop": "write",
+    "idk\s+lowkey": "or",
 }

--- a/testcases/echo_server.gyat
+++ b/testcases/echo_server.gyat
@@ -1,0 +1,54 @@
+glaze socket ahh skidoodle
+lock in asyncio glaze get_running_loop ahh lol
+glaze asyncio ahh vibes
+
+THE_CRIB = "0.0.0.0"
+CHUNK_THICCNESS = 1024
+CHILL_QUEUE = 10
+PORT = 1234
+
+outside bop link_up_with_homie(homie, addr):
+    loop = lol()
+    hawk:
+        let him cook Aura:
+            tea = touch grass loop.sock_recv(
+                homie,
+                CHUNK_THICCNESS,
+            )
+            chat is this real (
+                tea fr NPC
+                idk lowkey cap len(tea) sigma 0
+            ):
+                yap(f"{addr} left on read (RIP)")
+                its giving
+            yap(f"Yo, {addr} spilled '{tea}'")
+            touch grass loop.sock_sendall(homie, tea)
+    spit on that thang:
+        homie.close()
+
+bop create_clout_source():
+    clout = skidoodle.socket(skidoodle.AF_INET, skidoodle.SOCK_STREAM)
+    clout.setblocking(Cooked)
+    clout.setsockopt(skidoodle.SOL_SOCKET, skidoodle.SO_REUSEADDR, 1)
+    clout.bind((THE_CRIB, PORT))
+    its giving clout
+
+outside bop handle_clout(clout):
+    clout.listen(CHILL_QUEUE)
+    yap(f"We lit on port {PORT}")
+
+    loop = lol()
+    let him cook Aura:
+        homie, addr = touch grass loop.sock_accept(clout)
+        homie.setblocking(Cooked)
+        yap(f"Bro just pulled up from: {addr}")
+        vibes.create_task(link_up_with_homie(homie, addr))
+
+chat is this real __name__ twin "__main__":
+    cloute_provider = create_clout_source()
+    hawk:
+        vibes.run(handle_clout(cloute_provider))
+    tuah KeyboardInterrupt:
+        yap("Peace out...")
+    spit on that thang:
+        cloute_provider.close()

--- a/testcases/echo_server.gyat
+++ b/testcases/echo_server.gyat
@@ -9,7 +9,7 @@ PORT = 1234
 
 outside bop link_up_with_homie(homie, addr):
     loop = lol()
-    hawk:
+    pookie homie:
         let him cook Aura:
             tea = touch grass loop.sock_recv(
                 homie,
@@ -23,8 +23,6 @@ outside bop link_up_with_homie(homie, addr):
                 its giving
             yap(f"Yo, {addr} spilled '{tea}'")
             touch grass loop.sock_sendall(homie, tea)
-    spit on that thang:
-        homie.close()
 
 bop create_clout_source():
     clout = skidoodle.socket(skidoodle.AF_INET, skidoodle.SOCK_STREAM)


### PR DESCRIPTION
I swear this is lit as hell. New keywords mapped:
outside -> `async`
touch grass -> `await`
built like -> `=`
fr -> `is`
cap -> `not`
link up -> `and`
peep -> `read`
drop -> `write`
idk lowkey -> `or`.

I also implemented an entire echo-server natively in `pygyat` using the new terms. The whole process was lots of fun so I hope this will be merged quick.

The echo server implementation is added to  `testcases/`.